### PR TITLE
Create missing 'lib' directory and Makefile enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,25 @@ addons:
 script:
   - cd samples
   - sed -i 's/g++/g++-6/' makefile
+
+  # Execute the default recipe
   - make
+
+  # Test the parser with a TSP instance
+  - ./test ../instances/tsp-25-843.xml > /dev/null
+  # Test the parser with a Constraint Optimisation instance
+  - ./test ../instances/obj.xml > /dev/null
+  # Test the parser with an instance with all the kinds of constraints:
+  # This fails as the parser's sample solver doesn't support every constraint
+  - eval ! ./test ../instances/example.xml > /dev/null
+
+  # Execute the library recipes
+  - make lib
+  - make testlib
+
+  # Perform the three tests again for the 'testlib' executable
+  - ./testlib ../instances/tsp-25-843.xml > /dev/null
+  - ./testlib ../instances/obj.xml > /dev/null
+  - eval ! ./testlib ../instances/example.xml > /dev/null
+
+  - make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ addons:
       - g++-6
 
 script:
+  - CXX=g++-6
   - cd samples
-  - sed -i 's/g++/g++-6/' makefile
 
   # Execute the default recipe
   - make

--- a/samples/makefile
+++ b/samples/makefile
@@ -14,6 +14,7 @@ all: main.cc $(OBJ_FILES)
 	$(C++) $(CFLAGS) $(INC) -c -o $@ $<
 
 lib: $(OBJ_FILES) 
+	@mkdir -p ../lib
 	ar rcsv ../lib/libparserxcsp3core.a $(OBJ_FILES)
 
 testlib: main.cc

--- a/samples/makefile
+++ b/samples/makefile
@@ -1,4 +1,3 @@
-C++ = g++
 CFLAGS = -g -Wall -std=c++11 
 EXEC = test
 
@@ -7,18 +6,18 @@ INC = `xml2-config --cflags`  -I../include
 CPP_FILES := $(wildcard ../src/*.cc)
 OBJ_FILES := $(addprefix ../obj/,$(notdir $(CPP_FILES:.cc=.o)))
 all: main.cc $(OBJ_FILES) 
-	$(C++)  $(CFLAGS) $(INC) -o $(EXEC) $^ $(LIBS)
+	$(CXX)  $(CFLAGS) $(INC) -o $(EXEC) $^ $(LIBS)
 
 ../obj/%.o: ../src/%.cc
 	@mkdir -p ../obj
-	$(C++) $(CFLAGS) $(INC) -c -o $@ $<
+	$(CXX) $(CFLAGS) $(INC) -c -o $@ $<
 
 lib: $(OBJ_FILES) 
 	@mkdir -p ../lib
 	ar rcsv ../lib/libparserxcsp3core.a $(OBJ_FILES)
 
 testlib: main.cc
-	$(C++)  $(CFLAGS) $(INC) -o testlib main.cc -L ../lib $(LIBS) -lparserxcsp3core
+	$(CXX)  $(CFLAGS) $(INC) -o testlib main.cc -L ../lib $(LIBS) -lparserxcsp3core
 
 clean: 
 	rm -rf ../obj/*.o test ../lib/* testlib

--- a/samples/makefile
+++ b/samples/makefile
@@ -21,6 +21,6 @@ testlib: main.cc
 	$(C++)  $(CFLAGS) $(INC) -o testlib main.cc -L ../lib $(LIBS) -lparserxcsp3core
 
 clean: 
-	rm -rf ../obj/*.o test ../lib/*
+	rm -rf ../obj/*.o test ../lib/* testlib
 
 

--- a/samples/makefile
+++ b/samples/makefile
@@ -10,7 +10,7 @@ all: main.cc $(OBJ_FILES)
 	$(C++)  $(CFLAGS) $(INC) -o $(EXEC) $^ $(LIBS)
 
 ../obj/%.o: ../src/%.cc
-	-@(test -d "../obj") || mkdir ../obj
+	@mkdir -p ../obj
 	$(C++) $(CFLAGS) $(INC) -c -o $@ $<
 
 lib: $(OBJ_FILES) 


### PR DESCRIPTION
Good morning and thank you for accepting my previous pull request!

While trying to `make lib`, the corresponding directory wasn't created, and the build [failed](https://travis-ci.org/pothitos/XCSP3-CPP-Parser/builds/198268161#L366). To solve this, I added the missing `mkdir` command, and fortunately the build [passed](https://travis-ci.org/pothitos/XCSP3-CPP-Parser/builds/198268558). In order to validate this, I tested in the `.travis.yml` every Makefile command.

Secondly, I substituted the `C++` Makefile variable with the standard `CXX` one, which is by default set to `g++`.