### PR TITLE
Include required header file for runtime_error

### DIFF
--- a/include/XCSP3Domain.h
+++ b/include/XCSP3Domain.h
@@ -29,6 +29,7 @@
 #include <limits>
 #include <vector>
 #include <iostream>
+#include <stdexcept>
 
 using namespace std;
 namespace XCSP3Core {


### PR DESCRIPTION
Good morning!

I tried to use the parser with G++ 4.9, but the following errors occurred
```
In file included from ../src/XCSP3Code.cc:29:0:
../include/XCSP3Domain.h: In member function ‘void XCSP3Core::XDomainInteger::addValue(int)’:
../include/XCSP3Domain.h:165:23: error: ‘runtime_error’ is not a member of ‘std’
                 throw std::runtime_error{"not sequence domain"};
                       ^
../include/XCSP3Domain.h: In member function ‘void XCSP3Core::XDomainInteger::addInterval(int, int)’:
../include/XCSP3Domain.h:172:23: error: ‘runtime_error’ is not a member of ‘std’
                 throw std::runtime_error{"not sequence domain"};
                       ^
```

In order to solve this, I included in this pull request the required header file `stdexcept`.