### PR TITLE
fixed the name of LibXml2 in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(VERSION ${Xcsp3Parser_VERSION_MAJOR}.${Xcsp3Parser_VERSION_MINOR}.${Xcsp3Par
 #        "${PROJECT_SOURCE_DIR}/include/Xcsp3ParserConfig.h.in"
 #        "${PROJECT_BINARY_DIR}/include/Xcsp3ParserConfig.h"
 #)
-find_package(LibXML2 REQUIRED)
+find_package(LibXml2 REQUIRED)
 include_directories(${LIBXML2_INCLUDE_DIR})
 
 set(LIBRARY_NAME xcsp3parser)


### PR DESCRIPTION
The case of "LibXML2" in CMakeLists.txt is not the same as specified in the "FindLibXml2" CMake module.
This causes CMake  unable to find libxml2 on case-sensitive file systems such as ext4.