### PR TITLE
Define a copy ctor for UTF8String

### DIFF
--- a/include/UTF8String.h
+++ b/include/UTF8String.h
@@ -89,6 +89,8 @@ namespace XCSP3Core {
 
             explicit iterator(const Byte *s);
 
+            iterator(const iterator &);
+
             int operator*();
 
             iterator &operator++();

--- a/src/UTF8String.cc
+++ b/src/UTF8String.cc
@@ -334,6 +334,8 @@ UTF8String::iterator::iterator(const Byte *s) {
     p = s;
 }
 
+UTF8String::iterator::iterator(const iterator & o) : p(o.p) {
+}
 
 int UTF8String::iterator::operator*() {
     int ch = *p;


### PR DESCRIPTION
In C++20, the implicit copy ctor is deprecated for classes that define
an operator=. This is in a header that occurs in a public include file,
so this commit silences a compiler warning that would otherwise be seen
on every build.