### PR TITLE
handle nValues constraints with exceptions correctly

### DIFF
--- a/src/XMLParserTags.cc
+++ b/src/XMLParserTags.cc
@@ -746,7 +746,11 @@ void XMLParser::NValuesTagAction::beginTag(const AttributeList &attributes) {
 void XMLParser::NValuesTagAction::endTag() {
     constraint->list.assign(this->parser->lists[0].begin(), this->parser->lists[0].end());
     constraint->condition = this->parser->condition;
-    constraint->except.assign(this->parser->integers.begin(), this->parser->integers.end());
+    for (XEntity *xi : this->parser->values) {
+        int v;
+        isInteger(xi, v);
+        constraint->except.push_back(v);
+    }
     if(this->group == nullptr) {
         this->parser->manager->newConstraintNValues(constraint);
         delete constraint;


### PR DESCRIPTION
This if a fix for the bug that `nValues` constraints with exceptions (`<except>`) are not handled correctly.

Instance to reproduce:

```
<instance format="XCSP3" type="CSP">
  <variables>
    <var id="a"> 0..10 </var>
    <var id="b"> 0..10 </var>
    <var id="c"> 0..10 </var>
    <var id="d"> 0..10 </var>
    <var id="e"> 0..10 </var>
    <var id="f"> 0..10 </var>
  </variables>
  <constraints>
    <nValues id="nvalues1">
      <list> a b c d e f </list>
      <condition> (eq,3) </condition>
    </nValues>
    <nValues id="nvalues3">
      <list> a b c d e f </list>
      <except> 0 1 </except>
      <condition> (eq,2) </condition>
    </nValues>
  </constraints>
</instance>
```

Before fix, the sample parser shows something like

```
 start constraints declaration

    NValues  constraint
        a b c d e f 
        condition: = 3

    NValues  constraint
        a b c d e f 
        condition: = 2
```

After fix:

```
 start constraints declaration

    NValues  constraint
        a b c d e f 
        condition: = 3

    NValues with exceptions constraint
        a b c d e f 
        exceptions: 0 1 
        condition: = 2
```
