### PR TITLE
Add Support for Microsoft Visual C/C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,16 @@ include_directories(
 add_library(${LIBRARY_NAME} STATIC ${LIB_SOURCES} ${LIB_HEADERS})
 add_library(${LIBRARY_NAME_DYNAMIC} SHARED ${LIB_SOURCES} ${LIB_HEADERS})
 #add_library(${LIBRARY_NAME} SHARED ${LIB_SOURCES} ${LIB_HEADERS})
+
+if(MSVC)
+    target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_17)
+    target_compile_features(${LIBRARY_NAME_DYNAMIC} PUBLIC cxx_std_17)
+    target_compile_options(${LIBRARY_NAME} PRIVATE /W3)
+    target_compile_options(${LIBRARY_NAME_DYNAMIC} PRIVATE /W3)
+endif()
+
 target_link_libraries(${LIBRARY_NAME} ${LIBXML2_LIBRARIES})
+target_link_libraries(${LIBRARY_NAME_DYNAMIC} ${LIBXML2_LIBRARIES})
 
 set_target_properties(${LIBRARY_NAME} PROPERTIES
         VERSION ${VERSION}
@@ -79,4 +88,11 @@ add_executable(${APPLICATION_NAME} ${APP_SOURCES})
 target_link_libraries(${APPLICATION_NAME} ${LIBRARY_NAME} ${LIBXML2_LIBRARIES})
 target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-
+if(MSVC)
+    set_target_properties(${LIBRARY_NAME} PROPERTIES
+        DEBUG_POSTFIX d
+    )
+    set_target_properties(${LIBRARY_NAME_DYNAMIC} PROPERTIES
+        DEBUG_POSTFIX d
+    )
+endif()

--- a/include/XCSP3Tree.h
+++ b/include/XCSP3Tree.h
@@ -56,7 +56,7 @@ namespace XCSP3Core {
         Node *fromStringToTree(std::string);
 
         int arity() {
-            return listOfVariables.size();
+            return static_cast<int>(listOfVariables.size());
         }
 
 

--- a/include/XCSP3TreeNode.h
+++ b/include/XCSP3TreeNode.h
@@ -28,6 +28,7 @@
 
 #include<cmath>
 #include<iostream>
+#include <string>
 #include <vector>
 #include <map>
 #include<algorithm>
@@ -367,7 +368,7 @@ namespace XCSP3Core {
 
 
         int evaluate(std::map<std::string, int> &tuple) override {
-            return pow(parameters[0]->evaluate(tuple), parameters[1]->evaluate(tuple));
+            return (int)pow(parameters[0]->evaluate(tuple), parameters[1]->evaluate(tuple));
         }
     };
 

--- a/samples/XCSP3PrintCallbacks.h
+++ b/samples/XCSP3PrintCallbacks.h
@@ -310,7 +310,7 @@ void displayList(vector<T> &list, string separator = " ") {
         for(int i = 0; i < 3; i++)
             cout << list[i] << separator;
         cout << " ... ";
-        for(unsigned int i = list.size() - 4; i < list.size(); i++)
+        for(decltype(list.size()) i = list.size() - 4; i < list.size(); i++)
             cout << list[i] << separator;
         cout << endl;
         return;
@@ -326,7 +326,7 @@ void displayList(vector<XVariable *> &list, string separator = " ") {
         for(int i = 0; i < 3; i++)
             cout << list[i]->id << separator;
         cout << " ... ";
-        for(unsigned int i = list.size() - 4; i < list.size(); i++)
+        for(decltype(list.size()) i = list.size() - 4; i < list.size(); i++)
             cout << list[i]->id << separator;
         cout << endl;
         return;
@@ -643,10 +643,10 @@ void XCSP3PrintCallbacks::buildConstraintSum(string, vector<XVariable *> &list, 
         for(int i = 0; i < 3; i++)
             cout << (coeffs.size() == 0 ? 1 : coeffs[i]) << "*" << *(list[i]) << " ";
         cout << " ... ";
-        for(unsigned int i = list.size() - 4; i < list.size(); i++)
+        for(decltype(list.size()) i = list.size() - 4; i < list.size(); i++)
             cout << (coeffs.size() == 0 ? 1 : coeffs[i]) << "*" << *(list[i]) << " ";
     } else {
-        for(unsigned int i = 0; i < list.size(); i++)
+        for(decltype(list.size()) i = 0; i < list.size(); i++)
             cout << (coeffs.size() == 0 ? 1 : coeffs[i]) << "*" << *(list[i]) << " ";
     }
     cout << cond << endl;
@@ -670,10 +670,10 @@ void XCSP3PrintCallbacks::buildConstraintSum(string, vector<XVariable *> &list, 
         for(int i = 0; i < 3; i++)
             cout << coeffs[i]->id << "*" << *(list[i]) << " ";
         cout << " ... ";
-        for(unsigned int i = list.size() - 4; i < list.size(); i++)
+        for(decltype(list.size()) i = list.size() - 4; i < list.size(); i++)
             cout << coeffs[i]->id << "*" << *(list[i]) << " ";
     } else {
-        for(unsigned int i = 0; i < list.size(); i++)
+        for(decltype(list.size()) i = 0; i < list.size(); i++)
             cout << coeffs[i]->id << "*" << *(list[i]) << " ";
     }
     cout << cond << endl;
@@ -688,12 +688,12 @@ void XCSP3PrintCallbacks::buildConstraintSum(string id, vector<Tree *> &list, ve
             list[i]->prefixe();
         }
         cout << " ... ";
-        for(unsigned int i = list.size() - 4; i < list.size(); i++) {
+        for(decltype(list.size()) i = list.size() - 4; i < list.size(); i++) {
             cout << coeffs[i];
             list[i]->prefixe();
         }
     } else {
-        for(unsigned int i = 0; i < list.size(); i++) {
+        for(decltype(list.size()) i = 0; i < list.size(); i++) {
             cout << coeffs[i];
             list[i]->prefixe();
         }
@@ -707,11 +707,11 @@ void XCSP3PrintCallbacks::buildConstraintSum(string id, vector<Tree *> &list, XC
             list[i]->prefixe();
         }
         cout << " ... ";
-        for(unsigned int i = list.size() - 4; i < list.size(); i++) {
+        for(decltype(list.size()) i = list.size() - 4; i < list.size(); i++) {
             list[i]->prefixe();
         }
     } else {
-        for(unsigned int i = 0; i < list.size(); i++) {
+        for(decltype(list.size()) i = 0; i < list.size(); i++) {
             list[i]->prefixe();
         }
     }

--- a/src/UTF8String.cc
+++ b/src/UTF8String.cc
@@ -91,7 +91,7 @@ int UTF8String::byteLength() const {
             ++_end;
     }
 
-    return _end - _beg;
+    return static_cast<int>(_end - _beg);
 }
 
 

--- a/src/XCSP3Code.cc
+++ b/src/XCSP3Code.cc
@@ -167,9 +167,9 @@ XVariableArray::XVariableArray(std::string idd, XVariableArray *as) : sizes(as->
     indexes.assign(as->sizes.size(), 0);
     variables.assign(as->variables.size(), NULL);
     id = idd;
-    for(unsigned int i = 0 ; i < variables.size() ; i++) {
+    for(decltype(variables.size()) i = 0 ; i < variables.size() ; i++) {
         variables[i] = new XVariable(idd, as->variables[i]->domain, indexes);
-        for(int j = sizes.size() - 1 ; j >= 0 ; j--)
+        for(int j = static_cast<int>(sizes.size()/*unsigned*/) - 1 ; j >= 0 ; j--)
             if(++indexes[j] == sizes[j])
                 indexes[j] = 0;
             else
@@ -183,7 +183,7 @@ XVariableArray::~XVariableArray() {}
 
 void XVariableArray::indexesFor(int flatIndex, std::vector<int> &indexes) {
     indexes.resize(sizes.size());
-    for(int i = indexes.size() - 1 ; i > 0 ; i--) {
+    for(int i = static_cast<int>(indexes.size()) - 1; i > 0 ; i--) {
         indexes[i] = flatIndex % sizes[i];
         flatIndex = flatIndex / sizes[i];
     }
@@ -192,7 +192,7 @@ void XVariableArray::indexesFor(int flatIndex, std::vector<int> &indexes) {
 
 
 bool XVariableArray::incrementIndexes(vector<int> &indexes, vector<XIntegerEntity *> &ranges) {
-    int j = indexes.size() - 1;
+    int j = static_cast<int>(indexes.size()) - 1;
     for(; j >= 0 ; j--)
         if(ranges[j]->width() == 1)
             continue;
@@ -209,13 +209,13 @@ void XVariableArray::getVarsFor(vector<XVariable *> &list, string compactForm, v
     string tmp;
     // Compute the different ranges for all dimension
     for(unsigned int i = 0 ; i < sizes.size() ; i++) {
-        int pos = compactForm.find(']');
+        string::size_type pos = compactForm.find(']');
         tmp = compactForm.substr(1, pos - 1);
         compactForm = compactForm.substr(pos + 1);
         if(tmp.size() == 0) {
             ranges.push_back(new XIntegerInterval(0, sizes[i] - 1));
         } else {
-            size_t dot = tmp.find("..");
+            string::size_type dot = tmp.find("..");
             if(dot == string::npos)
                 ranges.push_back(new XIntegerValue(std::stoi(tmp)));
             else {
@@ -253,7 +253,7 @@ void XVariableArray::buildVarsWith(XDomainInteger *domain) {
     for(unsigned int i = 0 ; i < variables.size() ; i++) {
         if(variables[i] == NULL) // We need to create a variable
             variables[i] = new XVariable(id, domain, indexes);
-        for(int j = sizes.size() - 1 ; j >= 0 ; j--)
+        for(int j = static_cast<int>(sizes.size()) - 1 ; j >= 0 ; j--)
             if(++indexes[j] == sizes[j])
                 indexes[j] = 0;
             else
@@ -264,7 +264,7 @@ void XVariableArray::buildVarsWith(XDomainInteger *domain) {
 
 int XVariableArray::flatIndexFor(vector<int> indexes) {
     int sum = 0;
-    for(int i = indexes.size() - 1, nb = 1 ; i >= 0 ; i--) {
+    for(int i = static_cast<int>(indexes.size()) - 1, nb = 1; i >= 0 ; i--) {
         sum += indexes[i] * nb;
         nb *= sizes[i];
     }
@@ -312,7 +312,7 @@ void XConstraintGroup::unfoldVector(vector<XVariable *> &toUnfold, vector<XVaria
 
 
 void XConstraintGroup::unfoldString(string &toUnfold, vector<XVariable *> &args) {
-    for(int i = args.size() - 1 ; i >= 0 ; i--) {
+    for(int i = static_cast<int>(args.size()) - 1 ; i >= 0 ; i--) {
         string param = "%" + std::to_string(i);
         ReplaceStringInPlace(toUnfold, param, args[i]->id);
     }
@@ -374,7 +374,7 @@ void XInitialCondition::extract(XCondition &xc, string &condition) { // Create t
     if(tmp0 == "ne") xc.op = NE;
     //std::cout << condition <<": "<< tmp0 << " " <<tmp1 << std::endl;
     //printf("%d %d\n",' ',condition[condition.length()-1]);
-    size_t dotdot = tmp1.find('.');
+    string::size_type dotdot = tmp1.find('.');
     if(dotdot != string::npos) { // Normal variable
         xc.operandType = INTERVAL;
         xc.min = stoi(tmp1.substr(0, dotdot));
@@ -385,7 +385,7 @@ void XInitialCondition::extract(XCondition &xc, string &condition) { // Create t
     try {
         xc.val = stoi(tmp1);
         xc.operandType = INTEGER;
-    } catch(const invalid_argument &e) {
+    } catch(const invalid_argument &) {
         xc.var = tmp1;
         xc.operandType = VARIABLE;
     }
@@ -612,7 +612,6 @@ void XConstraintCircuit::unfoldParameters(XConstraintGroup *group, vector<XVaria
 void XConstraintClause::unfoldParameters(XConstraintGroup *group, vector<XVariable *> &arguments, XConstraint *original) {
 
     for(XVariable *xv : arguments) {
-        XTree *xt;
         if(dynamic_cast<XTree*>(xv) != nullptr) { // not
             if (xv->id.rfind("not(", 0) != 0)
                 throw runtime_error("a clause is malformed in a group: " + xv->id);
@@ -689,7 +688,7 @@ inline bool XCSP3Core::instanceof(const T *) {
 
 
 void XCSP3Core::ReplaceStringInPlace(std::string &subject, const std::string &search, const std::string &replace) {
-    size_t pos = 0;
+    std::string::size_type pos = 0;
     while((pos = subject.find(search, pos)) != std::string::npos) {
         subject.replace(pos, search.length(), replace);
         pos += replace.length();

--- a/src/XCSP3CoreParser.cc
+++ b/src/XCSP3CoreParser.cc
@@ -78,14 +78,14 @@ int XCSP3CoreParser::parse(istream &in) {
         xmlSubstituteEntitiesDefault(1);
 
         in.read(buffer.get(), bufSize);
-        size = in.gcount();
+        size = static_cast<int>(in.gcount());
 
         if(size > 0) {
             parserCtxt = xmlCreatePushParserCtxt(&handler, &cspParser, buffer.get(), size, filename);
 
             while(in.good()) {
                 in.read(buffer.get(), bufSize);
-                size = in.gcount();
+                size = static_cast<int>(in.gcount());
 
                 if(size > 0)
                     xmlParseChunk(parserCtxt, buffer.get(), size, 0);

--- a/src/XCSP3Manager.cc
+++ b/src/XCSP3Manager.cc
@@ -1069,7 +1069,7 @@ void XCSP3Manager::newConstraintNoOverlapKDim(XConstraintNoOverlap *constraint) 
     }
 
 
-    if(isInt > 0)
+    if(isInt)
         callback->buildConstraintNoOverlap(constraint->id, origins, intLengths, constraint->zeroIgnored);
     else
         callback->buildConstraintNoOverlap(constraint->id, origins, varLengths, constraint->zeroIgnored);

--- a/src/XCSP3Tree.cc
+++ b/src/XCSP3Tree.cc
@@ -58,7 +58,7 @@ static inline std::string &trim(std::string &s) {
 }
 
 template <typename T>
-static int min(T v1, T v2, T v3) {
+static T min(T v1, T v2, T v3) {
     if (v1 == -1) v1 = std::numeric_limits<T>::max();
     if (v2 == -1) v2 = std::numeric_limits<T>::max();
     if (v3 == -1) v3 = std::numeric_limits<T>::max();
@@ -72,16 +72,16 @@ Node *Tree::fromStringToTree(std::string current) {
     std::vector<NodeOperator*> stack;
     std::vector<Node*> params;
     while (true) {
-        int posOpenParenthesis = current.find('(');
-        int posCloseParenthesis = current.find(')');
-        int posComma = current.find(',');
-        int nb = min(posCloseParenthesis, posComma, posOpenParenthesis);
+        string::size_type posOpenParenthesis = current.find('(');
+        string::size_type posCloseParenthesis = current.find(')');
+        string::size_type posComma = current.find(',');
+        string::size_type nb = min(posCloseParenthesis, posComma, posOpenParenthesis);
 
 
         string currentElement = current.substr(0, nb);
         if (currentElement != "" && nb != posOpenParenthesis)
             createBasicParameter(currentElement,stack,params);
-        
+
 
         if (nb == posCloseParenthesis)
             closeOperator(stack,params);
@@ -114,12 +114,14 @@ void Tree::createOperator(string currentElement, std::vector<NodeOperator*> &sta
 void Tree::closeOperator(std::vector<NodeOperator*> &stack,std::vector<Node*> &params) {
     NodeOperator *tmp = stack.back();
 
-    int startParams = params.size() - 1;
+    assert(params.size() > 0);
+    int startParams = static_cast<int>(params.size()) - 1;
     while (params[startParams] != nullptr)
         startParams--;
     startParams++;
+
     int nbP = 0;
-    for (unsigned int i = startParams; i < params.size(); i++, nbP++)
+    for (decltype(params.size()) i = startParams; i < params.size(); i++, nbP++)
         tmp->addParameter(params[i]);
     stack.pop_back();
     //params.shrink(nbP);
@@ -143,7 +145,6 @@ void Tree::createBasicParameter(string currentElement, std::vector<NodeOperator*
             }
         if (position == -1) {
             listOfVariables.push_back(currentElement);
-            position = listOfVariables.size() - 1;
         }
         params.push_back(new NodeVariable(currentElement));
     }

--- a/src/XMLParser.cc
+++ b/src/XMLParser.cc
@@ -216,7 +216,7 @@ void XMLParser::parseSequence(const UTF8String &txt, vector<XVariable *> &list, 
         }
         size_t percent = current.find('%');
         if(percent == string::npos) { // Normal variable
-            size_t pos = current.find('[');
+            int pos = static_cast<int>(current.find('['));
             if(pos == string::npos) { // Not an array
                 size_t dotdot = current.find('.');
                 if(dotdot == string::npos) {
@@ -238,7 +238,7 @@ void XMLParser::parseSequence(const UTF8String &txt, vector<XVariable *> &list, 
                             list.push_back(xi);
                             toFree.push_back(xi);
                         }
-                    } catch(invalid_argument &e) {
+                    } catch(invalid_argument &) {
                         if(current == "*")
                             list.push_back(new XInteger(current, STAR));
                         else {
@@ -317,7 +317,7 @@ void XMLParser::parseDomain(const UTF8String &txt, XDomainInteger &domain) {
     UTF8String dotdot("..");
     while(tokenizer.hasMoreTokens()) {
         UTF8String token = tokenizer.nextToken();
-        size_t pos = token.find(dotdot);
+        int pos = token.find(dotdot);
 
         if(pos == UTF8String::npos) {
             int val;
@@ -345,7 +345,7 @@ void XMLParser::parseListOfIntegerOrInterval(const UTF8String &txt, vector<XInte
     UTF8String dotdot = "..";
     while(tokenizer.hasMoreTokens()) {
         UTF8String token = tokenizer.nextToken();
-        size_t pos = token.find(dotdot);
+        int pos = token.find(dotdot);
 
         if(pos == UTF8String::npos) {
             int val;

--- a/src/XMLParserTags.cc
+++ b/src/XMLParserTags.cc
@@ -257,7 +257,7 @@ void XMLParser::DomainTagAction::endTag() {
 
     split(forAttr, ' ', allCompactForms);
     for(auto & allCompactForm : allCompactForms) {
-        int pos = allCompactForm.find('[');
+        size_t pos = allCompactForm.find('[');
         name = allCompactForm.substr(0, pos);
         string compactForm = allCompactForm.substr(pos);
         vector<int> flatIndexes;
@@ -1329,7 +1329,6 @@ void XMLParser::ObjectivesTagAction::endTag() {
     if(this->parser->lists[0].size() > 0)
         objective->list.assign(this->parser->lists[0].begin(), this->parser->lists[0].end());
     if(this->parser->values.size() > 0) {
-        int value;
         objective->coeffs.assign(this->parser->values.begin(), this->parser->values.end());
     } else if(objective->type != EXPRESSION_O) {
         objective->coeffs.assign(objective->list.size(), new XInteger("1", 1));
@@ -1735,7 +1734,7 @@ void XMLParser::SlideTagAction::endTag() {
         throw runtime_error("Multiple lists in slide constraint is not yet supported");
 
 
-    unsigned long arity;
+    unsigned int arity;
     if(this->parser->nbParameters == 0) {
         XConstraintIntension *c = (XConstraintIntension *) group->constraint;
         int ar = 0;
@@ -1747,8 +1746,8 @@ void XMLParser::SlideTagAction::endTag() {
     } else
         arity = this->parser->nbParameters;
 
-    unsigned long end = circular ? list.size() - arity + 2 : list.size() - arity + 1;
-    for(unsigned int i = 0 ; i < end ; i += offset) {
+    decltype(list.size()) end = circular ? list.size() - arity + 2 : list.size() - arity + 1;
+    for(decltype(end) i = 0 ; i < end ; i += offset) {
         group->arguments.push_back(vector<XVariable *>());
         for(unsigned int j = 0 ; j < arity ; j++) {
             group->arguments.back().push_back(list[(i + j) % list.size()]);
@@ -1863,7 +1862,7 @@ void XMLParser::MatrixTagAction::text(const UTF8String txt, bool) {
     txt2 = trim(txt2);
     size_t p = txt2.find(("("));
     if(p == string::npos) {
-        size_t pos = txt2.find("[");
+        string::size_type pos = txt2.find("[");
         if(pos == string::npos)
             throw runtime_error("matrix needs a 2-dim matrix");
         string name;
@@ -1878,7 +1877,7 @@ void XMLParser::MatrixTagAction::text(const UTF8String txt, bool) {
         string tmp;
         // Find the first interval
         for(unsigned int i = 0 ; i < varArray->sizes.size() ; i++) {
-            int pos = compactForm.find(']');
+            pos = compactForm.find(']');
             tmp = compactForm.substr(1, pos - 1);
             compactForm = compactForm.substr(pos + 1);
             if(tmp.size() == 0) {
@@ -1896,10 +1895,10 @@ void XMLParser::MatrixTagAction::text(const UTF8String txt, bool) {
 
 
         this->parser->parseSequence(txt, this->parser->lists[0]);
-        int nbCol = this->parser->lists[0].size() / nbV;
+        size_t nbCol = this->parser->lists[0].size() / nbV;
         for(int i = 0 ; i < nbV ; i++) {
             this->parser->matrix.push_back(vector<XVariable *>());
-            for(int j = 0 ; j < nbCol ; j++)
+            for(decltype(nbCol) j = 0 ; j < nbCol ; j++)
                 this->parser->matrix.back().push_back(this->parser->lists[0][i * nbCol + j]);
         }
 


### PR DESCRIPTION
## Add support for Microsoft Visual C/C++

* Update CMakeLists.txt for MSVC.

* Add `cxx_std_17` to `target_compile_features` to raise the MSVC C++ standard level from C++11 to C++17.

* Fix MSVC /W3 compiler warnings about the unsafe subtraction of unsigned values where the result might be less than zero (e.g., `listOfVariables.size() - 1`).

* Fix MSVC /W3 compiler warnings for missing static casts: size_t (uint64_t) to int, ptrdiff_t to int, double to int, and string::size_type to int.

* Fix MSVC /W3 compiler warnings about unused vars.

* Fix a dubious cast of boolean `isInt` in `XCSP3Manager.cc`.